### PR TITLE
feat(lets-talk): add consulting booking flow with Cal.com

### DIFF
--- a/app/lets-talk/consulting-form.tsx
+++ b/app/lets-talk/consulting-form.tsx
@@ -1,0 +1,66 @@
+"use client"
+import { useEffect } from "react"
+import { getCalApi } from "@calcom/embed-react"
+import Cal from "@calcom/embed-react"
+
+const sessionTypes = [
+  {
+    value: "30min",
+    label: "30 min",
+    price: "$350 TTD",
+    description: "Best for a specific question, gut-check, or a decision you're stuck on.",
+    calLink: "andelh/book-a-consult?duration=30",
+  },
+  {
+    value: "60min",
+    label: "60 min",
+    price: "$600 TTD",
+    description: "Best for audits, architecture reviews, product strategy, or getting unstuck on something bigger.",
+    calLink: "andelh/book-a-consult?duration=60",
+  },
+]
+
+export default function ConsultingForm() {
+  useEffect(() => {
+    ;(async function () {
+      const cal = await getCalApi()
+      cal("ui", {
+        cssVarsPerTheme: {
+          light: { calBrand: "#000000" },
+          dark: { calBrand: "#29348F" },
+        },
+        hideEventTypeDetails: false,
+        layout: "month_view",
+      })
+    })()
+  }, [])
+
+  return (
+    <div className="max-w-2xl">
+      <Cal
+        calLink="andelh/book-a-consult?duration=30"
+        style={{ display: "none" }}
+      />
+      <p className="text-text-muted mb-6">
+        Choose the session length that fits your needs. Payment is collected at
+        checkout.
+      </p>
+      <div className="grid sm:grid-cols-2 gap-4">
+        {sessionTypes.map((session) => (
+          <button
+            key={session.value}
+            data-cal-link={session.calLink}
+            data-cal-config='{"layout":"month_view"}'
+            className="p-6 rounded-[0.625rem] border border-input bg-background shadow-xs hover:border-primary hover:cursor-pointer transition-all text-left"
+          >
+            <div className="flex items-center justify-between mb-3">
+              <span className="font-medium text-copy text-lg">{session.label}</span>
+              <span className="text-sm font-medium text-primary">{session.price}</span>
+            </div>
+            <p className="text-sm text-text-muted">{session.description}</p>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/lets-talk/contact-form.tsx
+++ b/app/lets-talk/contact-form.tsx
@@ -102,7 +102,7 @@ export default function ContactForm() {
           <FieldGroup>
             <Field>
               <FieldLabel htmlFor="projectType">I'm looking for a:</FieldLabel>
-              <Select onValueChange={value => setProjectType(value)}>
+              <Select onValueChange={value => setProjectType(value)} required>
                 <SelectTrigger
                   className="w-[180px]"
                   id="projectType"
@@ -155,8 +155,8 @@ export default function ContactForm() {
                   <Label htmlFor="yes">Yes</Label>
                 </div>
                 <div className="flex items-center space-x-2">
-                  <RadioGroupItem value="no" id="no" />
-                  <Label htmlFor="no">No</Label>
+                  <RadioGroupItem value="planning" id="no" />
+                  <Label htmlFor="no">Not yet, but I want to plan ahead</Label>
                 </div>
               </RadioGroup>
               <FieldDescription>

--- a/app/lets-talk/metadata.ts
+++ b/app/lets-talk/metadata.ts
@@ -1,0 +1,5 @@
+export const metadata = {
+  title: "Let's Talk | Andel Husbands",
+  description:
+    "Book a consulting session or start a project conversation with Andel Husbands, web and app developer based in Trinidad and Tobago.",
+}

--- a/app/lets-talk/page.tsx
+++ b/app/lets-talk/page.tsx
@@ -1,22 +1,89 @@
+"use client"
+import { useState } from "react"
 import ContactForm from "./contact-form"
+import ConsultingForm from "./consulting-form"
 
-export const metadata = {
-  title: "Contact me - Get a free quote | Andel Husbands",
-}
+type FormType = "project" | "consulting" | null
 
 export default function LetsTalkPage() {
+  const [activeForm, setActiveForm] = useState<FormType>(null)
+
   return (
     <div className="font-sans pt-10">
       <div className="mb-[40px]">
         <h1 className="mb-12 text-2xl md:text-5xl text-copy font-medium">
-          Let's Talk
+          Let&apos;s Talk
         </h1>
         <p className="text-text-muted mb-8 text-lg">
-          Tell me a bit about your project so we can get the ball rolling and
-          build something great together!
+          Tell me what you have in mind. I&apos;ll make sure we use our time
+          well.
         </p>
       </div>
-      <ContactForm />
+
+      {!activeForm && (
+        <div className="grid md:grid-cols-2 gap-6 max-w-4xl">
+          <button
+            onClick={() => setActiveForm("project")}
+            className="group text-left p-6 rounded-[0.625rem] border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground hover:cursor-pointer transition-all"
+          >
+            <span className="text-xs font-medium uppercase tracking-wider text-text-muted mb-2 block">
+              Build something
+            </span>
+            <h2 className="text-xl text-copy font-medium mb-2">
+              Start a project
+            </h2>
+            <p className="text-text-muted text-sm mb-4">
+            You have a website, app, or product you want to build.
+            </p>
+            <span className="text-primary text-sm font-medium group-hover:underline">
+              Tell me about your project →
+            </span>
+          </button>
+
+          <button
+            onClick={() => setActiveForm("consulting")}
+            className="group text-left p-6 rounded-[0.625rem] border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground hover:cursor-pointer transition-all"
+          >
+            <span className="text-xs font-medium uppercase tracking-wider text-text-muted mb-2 block">
+              Get consulting
+            </span>
+            <h2 className="text-xl text-copy font-medium mb-2">Book a session</h2>
+            <p className="text-text-muted text-sm mb-4">
+              You want expert eyes on a problem, a tech decision, or a strategy.
+              Paid, focused, and built around you.
+            </p>
+            <span className="text-primary text-sm font-medium group-hover:underline">
+              Book a session →
+            </span>
+          </button>
+        </div>
+      )}
+
+      {activeForm === "project" && (
+        <div>
+          <button
+            onClick={() => setActiveForm(null)}
+            className="text-sm text-text-muted hover:text-copy mb-6 flex items-center gap-1"
+          >
+            ← Back to options
+          </button>
+          <h2 className="text-xl text-copy font-medium mb-6">Project Inquiry</h2>
+          <ContactForm />
+        </div>
+      )}
+
+      {activeForm === "consulting" && (
+        <div>
+          <button
+            onClick={() => setActiveForm(null)}
+            className="text-sm text-text-muted hover:text-copy mb-6 flex items-center gap-1"
+          >
+            ← Back to options
+          </button>
+          <h2 className="text-xl text-copy font-medium mb-6">Book a Consult</h2>
+          <ConsultingForm />
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Split /lets-talk page into two paths: Project Inquiry and Book a Consult
- Added two-card entry point with progressive disclosure
- Created new consulting form with Cal.com popup embed for booking
- Updated affordability option copy in project form
- Added updated metadata for SEO

## Changes
- `app/lets-talk/page.tsx` - Entry point with two-card layout and form routing
- `app/lets-talk/contact-form.tsx` - Updated copy for affordability option
- `app/lets-talk/consulting-form.tsx` - New consulting booking form with Cal.com
- `app/lets-talk/metadata.ts` - Updated page metadata

## Testing
- [ ] Verify both entry cards display correctly on desktop and mobile
- [ ] Test progressive disclosure - selecting a card shows correct form
- [ ] Test back navigation from both forms
- [ ] Verify Cal.com popup opens with correct pre-selected duration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consulting session booking option with pricing, session duration choices, and calendar integration.
  * Added form selection flow allowing users to choose between project inquiry or booking a consultation session.

* **Refactor**
  * Restructured form display to conditionally render different form types with navigation controls.

* **Chores**
  * Updated form field requirement indicators and refined option labels for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/andelh/achweb/pull/53" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
